### PR TITLE
Update hero CTA with Twitch/YouTube watch links

### DIFF
--- a/script.js
+++ b/script.js
@@ -923,9 +923,22 @@ document.addEventListener('DOMContentLoaded', async () => {
                 // Not CFP phase, ensure countdown is visible
                 if (countdownContainer) countdownContainer.style.display = 'flex';
 
-                const msg = document.createElement('span');
-                msg.textContent = 'Registration coming soon';
-                heroCtaContainer.appendChild(msg);
+                const watchWrap = document.createElement('div');
+                watchWrap.className = 'hero-watch';
+                watchWrap.innerHTML = `
+                    <span class="hero-watch-label">Watch live on:</span>
+                    <div class="hero-watch-links">
+                        <a class="hero-watch-link" href="https://www.twitch.tv/awscdo" target="_blank" rel="noopener noreferrer">
+                            <i class="fa-brands fa-twitch" aria-hidden="true"></i>
+                            <span>Twitch</span>
+                        </a>
+                        <a class="hero-watch-link" href="https://www.youtube.com/@AWSCDO" target="_blank" rel="noopener noreferrer">
+                            <i class="fa-brands fa-youtube" aria-hidden="true"></i>
+                            <span>YouTube</span>
+                        </a>
+                    </div>
+                `.trim();
+                heroCtaContainer.appendChild(watchWrap);
                 if (cfpSection) cfpSection.style.display = 'none';
 
                 // Only start countdown if NOT in CFP mode

--- a/style.css
+++ b/style.css
@@ -295,6 +295,60 @@ nav a.active {
   margin: 0 auto;
 }
 
+.hero #hero-cta-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-watch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.hero-watch-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  opacity: 0.95;
+}
+
+.hero-watch-links {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero-watch-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  background: rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: transform var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.hero-watch-link:hover {
+  transform: translateY(-1px);
+  background: rgba(0, 0, 0, 0.26);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.hero-watch-link i {
+  font-size: 1.05rem;
+}
+
+.hero-watch-link .fa-youtube { color: #ff0000; }
+.hero-watch-link .fa-twitch { color: #a970ff; }
+
 .hero h1 {
   font-size: 3.5rem;
   font-weight: 800;


### PR DESCRIPTION
## Summary
- Replace the hero placeholder CTA with a polished "Watch live on" block.
- Add Twitch + YouTube links/icons for the livestream destinations.

## Test plan
- Load the site locally.
- Confirm hero shows "Watch live on:" with Twitch/YouTube links.
- Confirm no console errors.

Made with [Cursor](https://cursor.com)