### PR TITLE
fix(hero): prevent Register Now button flicker

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,6 @@
 
             <div id="hero-cta-container">
                 <!-- Smart Buttons injected here: Watch Live, Register, etc. -->
-                <button class="btn btn-primary" id="btn-register-trigger">Register Now</button>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Remove the hardcoded hero "Register Now" button from `index.html`.
- Prevent brief CTA flicker on refresh since hero CTAs are injected by `script.js`.

## Test plan
- Open the home page and refresh.
- Confirm the hero CTA does not flash "Register Now" and then disappear.
- Confirm the injected hero CTA renders normally and there are no console errors.

Made with [Cursor](https://cursor.com)